### PR TITLE
Add support for servers with prestrafe sourcemod plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/.idea
 **/*.iml
-
+.vscode/
 config.yml
 development.env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 FROM golang:alpine
 
 # Create application directory
-RUN mkdir /app
-ADD . /app/
-WORKDIR /app
+RUN mkdir /src
+ADD . /src/
+WORKDIR /src
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go mod download
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o run .
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/run .
 
 # Add the execution user
 RUN adduser -S -D -H -h /app execuser
 USER execuser
 
 # Run the application
-CMD ["./run"]
+CMD ["/app/run"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ content:
 channels:
   - name: SomeChannel # This is the name of the Twitch channel that the bot should join. 
     gsiToken: xxx # This can be any random string, that needs to be present in your CSGO GSI config as well. 
+    serverToken: xxx # Token string that will be registered in the server using sm_setprestrafetoken.
 ```
 
 Next you will need to define some environment variables to configure the bots execution context. To do so, create a file
@@ -25,6 +26,10 @@ BOT_GLOBALAPITOKEN=xxx
 # It depends on how you run the GSI backend, but most likely example values are correct for local development.
 BOT_GSIADDR=localhost
 BOT_GSIPORT=8080
+
+# The address and port of the SourceMod backend service that should be used by the bot.
+BOT_SMADDR=localhost
+BOT_SMPORT=8080
 
 # The Twitch.tv username and API token that should be used to talk to the Twitch Chat API.
 BOT_TWITCHUSERNAME=xxx
@@ -45,7 +50,7 @@ Of course, you need to run the GSI backend service before the bot will be able t
 
 - `!bpb (bonus-number) (map-name)`: Displays the personal best time for the bonus stage.
 - `!bwr (bonus-number) (map-name)`: Displays the world record time for the bonus stage.
-- `!globalcheck`: Yes
+- `!globalcheck`: Display global status of the server and player.
 - `!prestrafe`: A list of supported commands of the Prestrafe bot.
 - `!map (map-name)`: Displays information about the currently played map.
 - `!mode`: Displays the currently played KZ timer mode.
@@ -54,6 +59,8 @@ Of course, you need to run the GSI backend service before the bot will be able t
 - `!stats`: Displays a link to the GOKZ-Stats page.
 - `!tier (map-name)`: Display the difficulty level for the map.
 - `!wr (map-name)`: Displays the world record time for the main stage.
+- `!server`: Displays server information (name, global status)
+- `!run`: Displays current run information (Map name, course, checkpoints, teleports, time elapsed)
 
 ## Jumpstat Commands
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ called `development.env` inside the source code directory and add the following 
 
 ```properties
 # This is required because of limitations of Docker for Windows, we cannot mount the config file.
-BOT_CONFIGDIR=/app
+BOT_CONFIGDIR=/src
 
 # The API token the bot should used to authenticate against the Global API.
 BOT_GLOBALAPITOKEN=xxx

--- a/config/config_channel.go
+++ b/config/config_channel.go
@@ -1,6 +1,7 @@
 package config
 
 type ChannelConfig struct {
-	Name     string `yaml:"name"`
-	GsiToken string `yaml:"gsiToken"`
+	Name        string `yaml:"name"`
+	GsiToken    string `yaml:"gsiToken"`
+	ServerToken string `yaml:"serverToken"`
 }

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -21,6 +21,10 @@ spec:
               value: prestrafe-gsi.prestrafe.svc.cluster.local
             - name: BOT_GSIPORT
               value: "8080"
+            - name: BOT_SMADDR
+              value: prestrafe-gsi.prestrafe.svc.cluster.local
+            - name: BOT_SMPORT
+              value: "8080"
             - name: BOT_METRICPORT
               value: "9080"
             - name: BOT_TWITCHUSERNAME

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -24,4 +24,4 @@ commonLabels:
 images:
 - name: prestrafe-bot
   newName: jangraefen/prestrafe-bot
-  newTag: sha-cfe2f11
+  newTag: sha-b9c4cb7

--- a/globalapi/client.go
+++ b/globalapi/client.go
@@ -66,7 +66,7 @@ func (c *client) GetWithParameters(path string, queryParams QueryParameters, res
 
 	c.logger.Printf("%s -> Status: %d, Body: %s\n", response.Request.URL, response.StatusCode(), response.Body())
 	if response.StatusCode() != 200 {
-		return fmt.Errorf("Expected status '%d' but got '%d'", 200, response.StatusCode())
+		return fmt.Errorf("expected status '%d' but got '%d'", 200, response.StatusCode())
 	}
 
 	if jsonErr := json.Unmarshal(response.Body(), result); jsonErr != nil {

--- a/globalapi/map_service.go
+++ b/globalapi/map_service.go
@@ -1,6 +1,9 @@
 package globalapi
 
-import "strconv"
+import (
+	"regexp"
+	"strconv"
+)
 
 type KzMap struct {
 	Id                  int    `json:"id"`
@@ -13,6 +16,17 @@ type KzMap struct {
 	ApprovedBySteamId64 string `json:"approved_by_steamid64"`
 	WorkshopUrl         string `json:"workshop_url"`
 	DownloadUrl         string `json:"download_url"`
+}
+
+type RecordFilter struct {
+	Id        int32  `json:"id"`
+	MapId     int32  `json:"map_id"`
+	Stage     int32  `json:"stage"`
+	Mode      string `json:"mode"`
+	TickRate  int32  `json:"tickrate"`
+	CreatedOn string `json:"created_on"`
+	UpdatedOn string `json:"updated_on"`
+	UpdatedBy int64  `json:"updated_by"`
 }
 
 type MapServiceClient struct {
@@ -38,4 +52,38 @@ func (s *MapServiceClient) GetMapByName(mapName string) (result *KzMap, err erro
 	err = s.Get("maps/name/"+mapName, result)
 
 	return
+}
+
+func (s *MapServiceClient) GetMapIdByName(mapName string) (result int, err error) {
+	kzMap := &KzMap{}
+	err = s.Get("maps/name/"+mapName, kzMap)
+
+	return kzMap.Id, nil
+}
+
+func (s *MapServiceClient) CheckRecordFilter(stage int, mapName string, modeId int) string {
+	mapId, err := s.GetMapIdByName(mapName)
+	if err != nil {
+		return "Cannot establish a connection to the API server."
+	}
+	if mapId != 0 {
+		result := []RecordFilter{}
+
+		err = s.GetWithParameters("record_filters", QueryParameters{
+			"stages":   strconv.Itoa(stage),
+			"map_ids":  strconv.Itoa(mapId),
+			"mode_ids": strconv.Itoa(modeId),
+		}, &result)
+		if err != nil {
+			match, _ := regexp.MatchString(`Expected \d+, but got \d+ instead!`, err.Error())
+			if match {
+				return "Cannot establish a connection to the API server."
+			}
+		} else if len(result) == 0 {
+			return "No (Filter does not exist for this course)"
+		} else {
+			return "Yes"
+		}
+	}
+	return "No (Map does not exist in API database)"
 }

--- a/globalapi/map_service.go
+++ b/globalapi/map_service.go
@@ -54,30 +54,24 @@ func (s *MapServiceClient) GetMapByName(mapName string) (result *KzMap, err erro
 	return
 }
 
-func (s *MapServiceClient) GetMapIdByName(mapName string) (result int, err error) {
-	kzMap := &KzMap{}
-	err = s.Get("maps/name/"+mapName, kzMap)
-
-	return kzMap.Id, nil
-}
-
 func (s *MapServiceClient) CheckRecordFilter(stage int, mapName string, modeId int) string {
-	mapId, err := s.GetMapIdByName(mapName)
-	if err != nil {
-		return "Cannot establish a connection to the API server."
+	globalMap, apiError := s.GetMapByName(mapName)
+	if apiError != nil {
+		return "cannot establish a connection to the API server."
 	}
+	mapId := globalMap.Id
 	if mapId != 0 {
 		result := []RecordFilter{}
 
-		err = s.GetWithParameters("record_filters", QueryParameters{
+		apiError = s.GetWithParameters("record_filters", QueryParameters{
 			"stages":   strconv.Itoa(stage),
 			"map_ids":  strconv.Itoa(mapId),
 			"mode_ids": strconv.Itoa(modeId),
 		}, &result)
-		if err != nil {
-			match, _ := regexp.MatchString(`Expected \d+, but got \d+ instead!`, err.Error())
+		if apiError != nil {
+			match, _ := regexp.MatchString(`expected \d+, but got \d+ instead!`, apiError.Error())
 			if match {
-				return "Cannot establish a connection to the API server."
+				return "cannot establish a connection to the API server."
 			}
 		} else if len(result) == 0 {
 			return "No (Filter does not exist for this course)"

--- a/gsiclient/gamestate.go
+++ b/gsiclient/gamestate.go
@@ -6,10 +6,11 @@ import (
 )
 
 type GameState struct {
-	Auth     *AuthState     `json:"auth"`
-	Map      *MapState      `json:"map"`
-	Player   *PlayerState   `json:"player"`
-	Provider *ProviderState `json:"provider"`
+	Auth          *AuthState     `json:"auth"`
+	Map           *MapState      `json:"map"`
+	Player        *PlayerState   `json:"player"`
+	Provider      *ProviderState `json:"provider"`
+	PreviousState *GameState     `json:"previously"`
 }
 
 type AuthState struct {
@@ -25,7 +26,9 @@ type ProviderState struct {
 }
 
 type MapState struct {
-	Name string `json:"name"`
+	Name   string     `json:"name"`
+	TeamCT *TeamState `json:"team_ct"`
+	TeamT  *TeamState `json:"team_t"`
 }
 
 type PlayerState struct {
@@ -41,6 +44,10 @@ type MatchStats struct {
 	Deaths  int `json:"deaths"`
 	Mvps    int `json:"mvps"`
 	Score   int `json:"score"`
+}
+
+type TeamState struct {
+	Timeouts *int `json:"timeouts_remaining"`
 }
 
 func IsKZGameState(gameState *GameState) bool {

--- a/gsiclient/gsi_client.go
+++ b/gsiclient/gsi_client.go
@@ -30,7 +30,7 @@ func (c *client) GetGameState() (*GameState, error) {
 	response, restErr := resty.New().
 		R().
 		SetHeader("Authorization", fmt.Sprintf("GSI %s", c.authToken)).
-		Get(fmt.Sprintf("http://%s:%d/get", c.host, c.port))
+		Get(fmt.Sprintf("http://%s:%d/gsi/get", c.host, c.port))
 	if restErr != nil {
 		log.Println(restErr)
 		return nil, restErr

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -1,0 +1,51 @@
+package helper
+
+import (
+	"gitlab.com/prestrafe/prestrafe-bot/gsiclient"
+	"gitlab.com/prestrafe/prestrafe-bot/smclient"
+)
+
+// Check for data received from sourcemod and gsi backends and see if they match
+func CompareData(smData *smclient.FullPlayerInfo, gsiData *gsiclient.GameState) bool {
+
+	/* Team timeout check is to make sure that the server is doesn't send inaccurate player data.
+	These values will only match if the player is in the server, and change at frequent interval
+	to make sure the player is always in the server. */
+
+	// This can get out of sync if the server/client was slow to update, so we will also compare to previous data.
+	timeoutDelayed := (smData.TimeoutsCTPrev == *gsiData.Map.TeamCT.Timeouts) && (smData.TimeoutsTPrev == *gsiData.Map.TeamT.Timeouts)
+
+	timeoutAhead := gsiData.PreviousState != nil
+	// Make sure we don't have memory access violation
+	if timeoutAhead {
+		timeoutAhead = gsiData.PreviousState.Map != nil
+	}
+
+	if timeoutAhead {
+		timeoutAhead = (gsiData.PreviousState.Map.TeamCT != nil) && (gsiData.PreviousState.Map.TeamT != nil)
+	}
+
+	if timeoutAhead {
+		timeoutAhead = (gsiData.PreviousState.Map.TeamCT.Timeouts != nil) && (gsiData.PreviousState.Map.TeamT.Timeouts != nil)
+	}
+
+	if timeoutAhead {
+		timeoutAhead = (smData.TimeoutsCT == *gsiData.PreviousState.Map.TeamCT.Timeouts) && (smData.TimeoutsT == *gsiData.PreviousState.Map.TeamT.Timeouts)
+	}
+
+	timeoutInSync := (smData.TimeoutsCT == *gsiData.Map.TeamCT.Timeouts) && (smData.TimeoutsT == *gsiData.Map.TeamT.Timeouts)
+
+	timeoutCheck := timeoutDelayed || timeoutInSync || timeoutAhead
+
+	/* SM exclusive commands don't return anything if the player is spectating for now, because the three steamids don't match.
+	This is because currently GSI commands will return data about the spectated player and the SM backend might not have that data.
+	Therefore, it will be confusing if SM commands return the information of the original player.
+	However, it is likely possible to obtain and send the data of the spectated player instead. */
+
+	steamIDCheck := (smData.SteamId == gsiData.Player.SteamId) && (smData.SteamId == gsiData.Provider.SteamId)
+
+	// Server update is sent every 2 second. GSI update is sent every 2.5 seconds. A 6 seconds gap should be sufficient in case of packet loss.
+	timestampCheck := (smData.TimeStamp <= int(gsiData.Provider.Timestamp)+3) && (smData.TimeStamp >= int(gsiData.Provider.Timestamp)-3)
+
+	return timeoutCheck && steamIDCheck && timestampCheck
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"gitlab.com/prestrafe/prestrafe-bot/config"
 	"gitlab.com/prestrafe/prestrafe-bot/globalapi"
 	"gitlab.com/prestrafe/prestrafe-bot/gsiclient"
+	"gitlab.com/prestrafe/prestrafe-bot/smclient"
 	"gitlab.com/prestrafe/prestrafe-bot/twitchbot"
 )
 
@@ -17,6 +18,8 @@ type BotConfig struct {
 	GlobalApiToken string `required:"true"`
 	GsiAddr        string `required:"true"`
 	GsiPort        int    `required:"true"`
+	SmAddr         string `required:"true"`
+	SmPort         int    `required:"true"`
 	TwitchUsername string `required:"true"`
 	TwitchApiToken string `required:"true"`
 	ConfigDir      string `default:""`
@@ -50,10 +53,17 @@ func main() {
 func createCommands(botConfig *BotConfig, channelConfig *config.ChannelConfig) []twitchbot.ChatCommand {
 	apiClient := globalapi.NewClient(botConfig.GlobalApiToken)
 	gsiClient := gsiclient.New(botConfig.GsiAddr, botConfig.GsiPort, channelConfig.GsiToken)
+	smClient := smclient.New(botConfig.SmAddr, botConfig.SmPort, channelConfig.ServerToken)
 
 	commands := []twitchbot.ChatCommand{
-		// Troll commands
-		twitchbot.NewGlobalCheckCommand().Build(),
+		// Globalcheck command
+		twitchbot.NewGlobalCheckCommand(gsiClient, smClient, apiClient).Build(),
+
+		// Current run command
+		twitchbot.NewRunCommand(gsiClient, smClient).Build(),
+
+		// Server command
+		twitchbot.NewServerCommand(gsiClient, smClient).Build(),
 
 		// Map information commands
 		twitchbot.NewMapCommand(gsiClient, apiClient).Build(),

--- a/smclient/sm_client.go
+++ b/smclient/sm_client.go
@@ -1,0 +1,52 @@
+package smclient
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// This interfaces defines the public API of the GSI client. The client can be used to retrieve information about the
+// current game state of a player, by connecting to a running GSI server. It handles authentication automatically.
+type Client interface {
+	// Retrieves the game state for the player that this client connects to.
+	GetPlayerInfo() (*FullPlayerInfo, error)
+}
+
+type client struct {
+	host        string
+	port        int
+	serverToken string
+}
+
+func New(host string, port int, serverToken string) Client {
+	return &client{host, port, serverToken}
+}
+
+func (c *client) GetPlayerInfo() (*FullPlayerInfo, error) {
+	response, restErr := resty.New().
+		R().
+		SetHeader("Authorization", fmt.Sprintf("SM %s", c.serverToken)).
+		Get(fmt.Sprintf("http://%s:%d/get", c.host, c.port))
+	if restErr != nil {
+		log.Println(restErr)
+		return nil, restErr
+	}
+
+	if response.StatusCode() != 200 {
+		errorMessage := fmt.Sprintf("Expected status '%d' but got '%d', with response: %s", 200, response.StatusCode(), response.Body())
+		log.Println(errorMessage)
+		return nil, errors.New(errorMessage)
+	}
+
+	result := new(FullPlayerInfo)
+	if jsonErr := json.Unmarshal(response.Body(), result); jsonErr != nil {
+		log.Println(jsonErr)
+		return nil, jsonErr
+	}
+
+	return result, nil
+}

--- a/smclient/sm_client.go
+++ b/smclient/sm_client.go
@@ -9,8 +9,6 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-// This interfaces defines the public API of the GSI client. The client can be used to retrieve information about the
-// current game state of a player, by connecting to a running GSI server. It handles authentication automatically.
 type Client interface {
 	// Retrieves the game state for the player that this client connects to.
 	GetPlayerInfo() (*FullPlayerInfo, error)
@@ -30,7 +28,7 @@ func (c *client) GetPlayerInfo() (*FullPlayerInfo, error) {
 	response, restErr := resty.New().
 		R().
 		SetHeader("Authorization", fmt.Sprintf("SM %s", c.serverToken)).
-		Get(fmt.Sprintf("http://%s:%d/get", c.host, c.port))
+		Get(fmt.Sprintf("http://%s:%d/sm/get", c.host, c.port))
 	if restErr != nil {
 		log.Println(restErr)
 		return nil, restErr

--- a/smclient/sm_playerinfo.go
+++ b/smclient/sm_playerinfo.go
@@ -1,0 +1,26 @@
+package smclient
+
+type FullPlayerInfo struct {
+	TimeStamp      int     `json:"timestamp"`
+	AuthKey        string  `json:"authkey"`
+	TimeoutsCTPrev int     `json:"timeoutsCTprev"`
+	TimeoutsTPrev  int     `json:"timeoutsTprev"`
+	TimeoutsCT     int     `json:"timeoutsCT"`
+	TimeoutsT      int     `json:"timeoutsT"`
+	ServerName     string  `json:"servername"`
+	MapName        string  `json:"mapname"`
+	ServerGlobal   int     `json:"serverglobal"`
+	SteamId        int64   `json:"steamid,string"`
+	Clan           string  `json:"clan"`
+	Name           string  `json:"name"`
+	TimeInServer   float64 `json:"timeinserver"` // Need a better name
+	KZData         KZData  `json:"KZData"`
+}
+
+type KZData struct {
+	Global      bool    `json:"global"`
+	Course      int     `json:"course"`
+	Time        float64 `json:"time"`
+	Checkpoints int     `json:"checkpoints"`
+	Teleports   int     `json:"teleports"`
+}

--- a/twitchbot/kz_command_globalcheck.go
+++ b/twitchbot/kz_command_globalcheck.go
@@ -1,9 +1,44 @@
 package twitchbot
 
-func NewGlobalCheckCommand() ChatCommandBuilder {
+import (
+	"errors"
+
+	"gitlab.com/prestrafe/prestrafe-bot/globalapi"
+	"gitlab.com/prestrafe/prestrafe-bot/gsiclient"
+	"gitlab.com/prestrafe/prestrafe-bot/helper"
+	"gitlab.com/prestrafe/prestrafe-bot/smclient"
+)
+
+func NewGlobalCheckCommand(gsiClient gsiclient.Client, smClient smclient.Client, apiClient globalapi.Client) ChatCommandBuilder {
 	return NewChatCommandBuilder("globalcheck").
 		WithAlias("gc").
-		WithHandler(func(ctx CommandContext) (msg string, err error) {
-			return "Yes", nil
-		})
+		WithHandler(createGCHandler(gsiClient, smClient, apiClient))
+}
+
+func createGCHandler(gsiClient gsiclient.Client, smClient smclient.Client, apiClient globalapi.Client) ChatCommandHandler {
+	return func(ctx CommandContext) (message string, err error) {
+		gameState, gsiError := gsiClient.GetGameState()
+		if gsiError != nil || !gsiclient.IsKZGameState(gameState) {
+			return "", errors.New("could not retrieve KZ game play")
+		}
+		fullPlayerState, smError := smClient.GetPlayerInfo()
+
+		if smError != nil {
+			return "", errors.New("could not retrieve KZ gameplay from game server")
+		}
+		if !helper.CompareData(fullPlayerState, gameState) {
+			return "", errors.New("could not match KZ gameplay from game server")
+		}
+		if fullPlayerState.ServerGlobal == -1 {
+			return "", errors.New("could not retrieve server global status")
+		}
+		if fullPlayerState.ServerGlobal == 0 {
+			return "no (Server is not global)", nil
+		}
+		if !fullPlayerState.KZData.Global {
+			return "no (Player is not verified)", nil
+		}
+
+		return (&globalapi.MapServiceClient{Client: apiClient}).CheckRecordFilter(fullPlayerState.KZData.Course, fullPlayerState.MapName, gsiclient.TimerModeId(gameState.Player)), nil
+	}
 }

--- a/twitchbot/kz_command_run.go
+++ b/twitchbot/kz_command_run.go
@@ -1,0 +1,56 @@
+package twitchbot
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"gitlab.com/prestrafe/prestrafe-bot/gsiclient"
+	"gitlab.com/prestrafe/prestrafe-bot/helper"
+	"gitlab.com/prestrafe/prestrafe-bot/smclient"
+)
+
+func NewRunCommand(gsiClient gsiclient.Client, smClient smclient.Client) ChatCommandBuilder {
+	return NewChatCommandBuilder("run").
+		WithHandler(createRunHandler(gsiClient, smClient))
+}
+
+func createRunHandler(gsiClient gsiclient.Client, smClient smclient.Client) ChatCommandHandler {
+	return func(ctx CommandContext) (message string, err error) {
+		gameState, gsiError := gsiClient.GetGameState()
+		if gsiError != nil || !gsiclient.IsKZGameState(gameState) {
+			return "", errors.New("could not retrieve KZ gameplay")
+		}
+		fullPlayerState, smError := smClient.GetPlayerInfo()
+		if smError != nil {
+			return "", errors.New("could not retrieve data from game server")
+		}
+		if !helper.CompareData(fullPlayerState, gameState) {
+			return "", errors.New("could not match data from game server with GSI client")
+		}
+
+		var course string
+		// Course
+		if fullPlayerState.KZData.Course == 0 {
+			course = "Main"
+		} else {
+			course = fmt.Sprintf("Bonus %d", fullPlayerState.KZData.Course)
+		}
+
+		// Time
+		hours := math.Floor(fullPlayerState.KZData.Time / 60 / 60)
+		minutes := math.Floor(fullPlayerState.KZData.Time/60) - hours*60
+		seconds := fullPlayerState.KZData.Time - hours*3600 - minutes*60
+
+		var time string
+		if hours > 0 {
+			time = fmt.Sprintf("%02d:%02d:%05.2f", int(hours), int(minutes), seconds)
+		} else if minutes > 0 {
+			time = fmt.Sprintf("%02d:%05.2f", int(minutes), seconds)
+		} else {
+			time = fmt.Sprintf("%05.2f", seconds)
+		}
+
+		return fmt.Sprintf("Map: %s, Course: %s, Checkpoints: %d, Teleports: %d, Time elapsed: %s", fullPlayerState.MapName, course, fullPlayerState.KZData.Checkpoints, fullPlayerState.KZData.Teleports, time), nil
+	}
+}

--- a/twitchbot/kz_command_server.go
+++ b/twitchbot/kz_command_server.go
@@ -1,0 +1,39 @@
+package twitchbot
+
+import (
+	"errors"
+	"fmt"
+
+	"gitlab.com/prestrafe/prestrafe-bot/gsiclient"
+	"gitlab.com/prestrafe/prestrafe-bot/helper"
+	"gitlab.com/prestrafe/prestrafe-bot/smclient"
+)
+
+func NewServerCommand(gsiClient gsiclient.Client, smClient smclient.Client) ChatCommandBuilder {
+	return NewChatCommandBuilder("server").
+		WithHandler(createServerHandler(gsiClient, smClient))
+}
+
+func createServerHandler(gsiClient gsiclient.Client, smClient smclient.Client) ChatCommandHandler {
+	return func(ctx CommandContext) (message string, err error) {
+		gameState, gsiError := gsiClient.GetGameState()
+		if gsiError != nil || !gsiclient.IsKZGameState(gameState) {
+			return "", errors.New("could not retrieve KZ gameplay")
+		}
+		fullPlayerState, smError := smClient.GetPlayerInfo()
+		if smError != nil {
+			return "", errors.New("could not retrieve data from game server")
+		}
+		if !helper.CompareData(fullPlayerState, gameState) {
+			return "", errors.New("could not match data from game server with GSI client")
+		}
+
+		global := "N/A"
+		if fullPlayerState.ServerGlobal == 1 {
+			global = "Yes"
+		} else if fullPlayerState.ServerGlobal == 0 {
+			global = "No"
+		}
+		return fmt.Sprintf("Current server: %s. Global status: %s", fullPlayerState.ServerName, global), nil
+	}
+}


### PR DESCRIPTION
Using data sent by the game server, you can fetch a lot more information about the player than API queries.

While this require a [plugin](https://github.com/prestrafe/prestrafe-smplugin) to be installed on the server side, it isn't limited by the GlobalAPI query limit.

Current features:
- Globalcheck (for real now)
- Server information (only names and global status for now)
- Current run information (map name, course, checkpoints, teleports, time elapsed)

Planned features:
- Server jumpstats (GOKZ jumpstats aren't global, so this would be a better temporary solution) and maybe more related data (eg. server records, could be useful for non global maps)
- [More Stats](https://github.com/zer0k-z/more-stats) integration for even more statistics

The migration from GitLab seems to break the entire `sourcemod` branch in prestrafe repository, so I just create a new branch from the master branch in my fork instead.